### PR TITLE
RSDP Typo

### DIFF
--- a/02_Architecture/06_ACPITables.md
+++ b/02_Architecture/06_ACPITables.md
@@ -124,8 +124,8 @@ The RSDT is an SDT header followed by an array of `uint32_t`s, representing the 
 The XSDT is the same, except the array is of `uint64_t`s.
 
 ```c
-struct RSDP {
-    ACPISDTHeader sdtHeader; //signature "RSDP"
+struct RSDT {
+    ACPISDTHeader sdtHeader; //signature "RSDT"
     uint32_t sdtAddresses[];
 };
 


### PR DESCRIPTION
The signature for the RSDP is "RSD PTR ", and it is not an SDT. 

https://uefi.org/specs/ACPI/6.5/05_ACPI_Software_Programming_Model.html?highlight=rsdt#root-system-description-table-rsdt