### PR TITLE
APIC Address Incorrect

### DIFF
--- a/02_Architecture/07_APIC.md
+++ b/02_Architecture/07_APIC.md
@@ -63,10 +63,10 @@ This register contains the following information:
 * Bit 8: if set, it means that the processor is the Bootstrap Processor (BSP).
 * Bits 9:10: reserved.
 * Bit 11: APIC global enable. This bit can be cleared to disable the local APIC for this processor. Realistically there is no reason to do this on modern processors.
-* Bits 12:31: Contains the base address of the local APIC for this processor core.
+* Bits 12:31: Contains the base address of the local APIC for this processor core. NOTE: The value read from these bits should not be shifted, e.g. if you read ``0xFEE00``, then the address is ``0xFEE00000``, just with bits 0:11 zeroed out.  
 * Bits 32:63: reserved.
 
-Note that the registers are given as a *physical address*, so to access these we will need to map them somewhere in the virtual address space. This is true for the addresses of any I/O APICs we obtain as well. When the system boots, the base address is usually `0xFEE0000` and often this is the value we read from `rdmsr`. For correct operation the local APIC registers should be mapped as 'strong uncachable'.
+Note that the registers are given as a *physical address*, so to access these we will need to map them somewhere in the virtual address space. This is true for the addresses of any I/O APICs we obtain as well. When the system boots, the base address is usually `0xFEE00000` and often this is the value we read from `rdmsr`. For correct operation the local APIC registers should be mapped as 'strong uncachable'.
 
 A complete list of local APIC registers is available in the Intel/AMD software development manuals, but the important ones for now are:
 


### PR DESCRIPTION
Fixed the description of the APIC address (the physaddr is not shifted, but the lower bits are masked), and fixed a typo with the location. On my ``qemu-system-x86_64``, the LAPIC base is 0xFEE00000 in physical memory.